### PR TITLE
Fixed cache issue

### DIFF
--- a/get-tweets-hashtag/get-tweets-hashtag.php
+++ b/get-tweets-hashtag/get-tweets-hashtag.php
@@ -104,14 +104,14 @@ function get_tweets_cache($hashtag, $count) {
     $table_name = $wpdb->prefix . "get_tweets";
     $results = $wpdb->get_results("select * from $table_name where hashtag = '" . $hashtag . "' LIMIT 1");
     if (count($results) > 0) {
-        if (($results['0']->created) < date('H')) {
+        if (($results['0']->created) < date('jH')) {
             //serialize, compress, and encode since its a json object...
             $tweets = base64_encode(gzcompress(serialize(get_tweets_find($hashtag, $count))));
             $wpdb->insert(
                 $table_name,
                 array(
                     'hashtag' => $hashtag,
-                    'created' => date('H'),
+                    'created' => date('jH'),
                     'cache' => $tweets
                 )
             );
@@ -122,7 +122,7 @@ function get_tweets_cache($hashtag, $count) {
             $table_name,
             array(
                 'hashtag' => $hashtag,
-                'created' => date('H'),
+                'created' => date('jH'),
                 'cache' => $tweets
             )
         );


### PR DESCRIPTION
Added the day (j) behind the hour. Without it, if the date (for example) was 2am on Tuesday while the Tweet was last pulled on Monday at 3am, the code thought that since 3>2 the Tweet did not need to be refreshed... With the j that solves it 
